### PR TITLE
Reverts Ni's patch, re-adds arcdps references with chainloaded name

### DIFF
--- a/src/arcdps_mechanicslog.cpp
+++ b/src/arcdps_mechanicslog.cpp
@@ -28,10 +28,26 @@ uintptr_t mod_combat(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t i
 uintptr_t mod_imgui(uint32_t not_charsel_or_loading);
 uintptr_t mod_options();
 static int changeExportPath(ImGuiTextEditCallbackData const *data);
+void readArcExports();
 void parseIni();
 void writeIni();
+bool modsPressed();
+bool canMoveWindows();
+bool canClickWindows();
 
 typedef uint64_t(*arc_export_func_u64)();
+auto arc_dll = LoadLibraryA(TEXT("d3d9.dll"));
+auto arc_export_e6 = (arc_export_func_u64)GetProcAddress(arc_dll, "e6");
+bool arc_hide_all = false;
+bool arc_panel_always_draw = false;
+bool arc_movelock_altui = false;
+bool arc_clicklock_altui = false;
+bool arc_window_fastclose = false;
+
+auto arc_export_e7 = (arc_export_func_u64)GetProcAddress(arc_dll, "e7");
+DWORD arc_global_mod1 = 0;
+DWORD arc_global_mod2 = 0;
+DWORD arc_global_mod_multi = 0;
 
 bool show_app_log = false;
 AppLog log_ui;
@@ -118,11 +134,11 @@ uintptr_t mod_wnd(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	auto const io = &ImGui::GetIO();
 
-	if (uMsg == WM_KEYUP || uMsg == WM_KEYDOWN || uMsg == WM_SYSKEYUP || uMsg == WM_SYSKEYDOWN)
+	switch (uMsg)
 	{
-		const int vkey = (int)wParam;
-		if (uMsg == WM_KEYUP || uMsg == WM_SYSKEYUP)
+		case WM_KEYUP:
 		{
+			const int vkey = (int)wParam;
 			io->KeysDown[vkey] = 0;
 			if (vkey == VK_CONTROL)
 			{
@@ -136,9 +152,11 @@ uintptr_t mod_wnd(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			{
 				io->KeyShift = false;
 			}
+			break;
 		}
-		else
+		case WM_KEYDOWN:
 		{
+			const int vkey = (int)wParam;
 			io->KeysDown[vkey] = 1;
 			if (vkey == VK_CONTROL)
 			{
@@ -152,7 +170,59 @@ uintptr_t mod_wnd(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			{
 				io->KeyShift = true;
 			}
+			break;
 		}
+		case WM_SYSKEYUP:
+		{
+			const int vkey = (int)wParam;
+			io->KeysDown[vkey] = 0;
+			if (vkey == VK_CONTROL)
+			{
+				io->KeyCtrl = false;
+			}
+			else if (vkey == VK_MENU)
+			{
+				io->KeyAlt = false;
+			}
+			else if (vkey == VK_SHIFT)
+			{
+				io->KeyShift = false;
+			}
+			break;
+		}
+		case WM_SYSKEYDOWN:
+		{
+			const int vkey = (int)wParam;
+			io->KeysDown[vkey] = 1;
+			if (vkey == VK_CONTROL)
+			{
+				io->KeyCtrl = true;
+			}
+			else if (vkey == VK_MENU)
+			{
+				io->KeyAlt = true;
+			}
+			else if (vkey == VK_SHIFT)
+			{
+				io->KeyShift = true;
+			}
+			break;
+		}
+		case WM_ACTIVATEAPP:
+		{
+			if (!wParam)
+			{
+				io->KeysDown[arc_global_mod1] = false;
+				io->KeysDown[arc_global_mod2] = false;
+			}
+			break;
+		}
+		break;
+	}
+
+	if (io->KeysDown[arc_global_mod1] && io->KeysDown[arc_global_mod2])
+	{
+		if (io->KeysDown[log_key] || io->KeysDown[chart_key]) return 0;
 	}
 
 	return uMsg;
@@ -304,14 +374,16 @@ uintptr_t mod_combat(cbtevent* ev, ag* src, ag* dst, char* skillname, uint64_t i
 
 void ShowMechanicsLog(bool* p_open)
 {
-	if(show_app_log) log_ui.draw("Mechanics Log", p_open, ImGuiWindowFlags_NoCollapse, &tracker);
+	if(show_app_log) log_ui.draw("Mechanics Log", p_open, ImGuiWindowFlags_NoCollapse
+		| (!canMoveWindows() ? ImGuiWindowFlags_NoMove : 0), &tracker);
 }
 
 void ShowMechanicsChart(bool* p_open)
 {
 	if (show_app_chart)
 	{
-		chart_ui.draw(&tracker, "Mechanics Chart", p_open, ImGuiWindowFlags_NoCollapse, true);
+		chart_ui.draw(&tracker, "Mechanics Chart", p_open, ImGuiWindowFlags_NoCollapse
+			| (!canMoveWindows() ? ImGuiWindowFlags_NoMove : 0), arc_clicklock_altui);
 	}
 }
 
@@ -319,24 +391,29 @@ void ShowMechanicsOptions(bool* p_open)
 {
 	if (show_options)
 	{
-		options_ui.draw(&tracker, "Mechanics Options", p_open, ImGuiWindowFlags_NoCollapse);
+		options_ui.draw(&tracker, "Mechanics Options", p_open, ImGuiWindowFlags_NoCollapse
+			| (!canMoveWindows() ? ImGuiWindowFlags_NoMove : 0));
 	}
 }
 
 uintptr_t mod_imgui(uint32_t not_charsel_or_loading)
 {
-
+	readArcExports();
+	
 	if (!not_charsel_or_loading) return 0;
 
 	auto const io = &ImGui::GetIO();
 
-	if (ImGui::IsKeyPressed(log_key))
+	if (io->KeysDown[arc_global_mod1] && io->KeysDown[arc_global_mod2])
 	{
-		show_app_log = !show_app_log;
-	}
-	if (ImGui::IsKeyPressed(chart_key))
-	{
-		show_app_chart = !show_app_chart;
+		if (ImGui::IsKeyPressed(log_key))
+		{
+			show_app_log = !show_app_log;
+		}
+		if (ImGui::IsKeyPressed(chart_key))
+		{
+			show_app_chart = !show_app_chart;
+		}
 	}
 	
 	ShowMechanicsLog(&show_app_log);
@@ -364,6 +441,27 @@ uintptr_t mod_options()
 static int changeExportPath(ImGuiTextEditCallbackData const *data)
 {
 	chart_ui.export_dir = data->Buf;
+}
+
+void readArcExports()
+{
+	uint64_t e6_result = arc_export_e6();
+	uint64_t e7_result = arc_export_e7();
+
+	arc_hide_all = (e6_result & 0x01);
+	arc_panel_always_draw = (e6_result & 0x02);
+	arc_movelock_altui = (e6_result & 0x04);
+	arc_clicklock_altui = (e6_result & 0x08);
+	arc_window_fastclose = (e6_result & 0x10);
+
+
+	uint16_t* ra = (uint16_t*)&e7_result;
+	if (ra)
+	{
+		arc_global_mod1 = ra[0];
+		arc_global_mod2 = ra[1];
+		arc_global_mod_multi = ra[2];
+	}
 }
 
 void parseIni()
@@ -439,4 +537,35 @@ void writeIni()
 	}
 
 	rc = mechanics_ini.SaveFile("addons\\arcdps\\arcdps_mechanics.ini");
+}
+
+bool modsPressed()
+{
+	auto io = &ImGui::GetIO();
+
+	return io->KeysDown[arc_global_mod1] && io->KeysDown[arc_global_mod2];
+}
+
+bool canMoveWindows()
+{
+	if (!arc_movelock_altui)
+	{
+		return true;
+	}
+	else
+	{
+		return modsPressed();
+	}
+}
+
+bool canClickWindows()
+{
+	if (!arc_clicklock_altui)
+	{
+		return true;
+	}
+	else
+	{
+		return modsPressed();
+	}
 }


### PR DESCRIPTION
Title.
The patch wasn't meant as a proper solution but to remove all traces of arcdps.
Currently (with default keybinds) charts/log are toggled when the user presses `L`/`N` without key modifiers.